### PR TITLE
Change ignore list to filter predicate

### DIFF
--- a/lib/alarms.js
+++ b/lib/alarms.js
@@ -10,12 +10,14 @@ function Alarms(){
  * Retrive all CloudWatch Alarms.
  * Returns a Promise containing a JS object with all configured alarms.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Object} params - Additional AWS Filters.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Object} params - Additional AWS Parameters for describe-alarms.
+ * @param {Function} filter - A predicate that receives a MetricAlarm map and
+ * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.getAllAlarms = function(auth, params, ignore, prevResults){
+Alarms.prototype.getAllAlarms = function(auth, params, filter, prevResults){
 	var self = this;
 	params = params || {};
+
 	var cloudwatch = new AWS.cloudWatch(auth.props);
 	return cloudwatch.describeAlarmsPromised(params)
 	.then(function(data) {
@@ -24,16 +26,16 @@ Alarms.prototype.getAllAlarms = function(auth, params, ignore, prevResults){
 		}
 		if (data.NextToken) {
 			params.NextToken = data.NextToken;
-			return self.getAllAlarms(auth, params, ignore, data);
+			return self.getAllAlarms(auth, params, filter, data);
 		} else {
-			if (ignore) {
-				var nonIgnoredAlarms = [];
+			if (filter) {
+				var filteredAlarms = [];
 				for (var alarmIdx = 0; alarmIdx < data.MetricAlarms.length; alarmIdx++) {
-					if(!(_.includes(ignore, data.MetricAlarms[alarmIdx].AlarmName))) {
-						nonIgnoredAlarms.push(data.MetricAlarms[alarmIdx]);
+					if(filter(data.MetricAlarms[alarmIdx])) {
+						filteredAlarms.push(data.MetricAlarms[alarmIdx]);
 					}
 				}
-				data.MetricAlarms = nonIgnoredAlarms;
+				data.MetricAlarms = filteredAlarms;
 			}
 			return Promise.resolve(data);
 		}
@@ -44,27 +46,29 @@ Alarms.prototype.getAllAlarms = function(auth, params, ignore, prevResults){
  * Returns a Promise containing a JS object with all of the alarms currently in that state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByState = function(state, auth, ignore){
-	return this.getAllAlarms(auth, {StateValue : state}, ignore);
+Alarms.prototype.queryAlarmsByState = function(state, auth, filter){
+	return this.getAllAlarms(auth, {StateValue : state}, filter);
 };
 /**
  * Queries Cloudwatch alarms that are currently in a particular state.
  * Returns a Promise that resolves to a string containing information about each alarm in the queried state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, ignore){
-	return this.queryAlarmsByState(state, auth, ignore)
+Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, filter){
+	return this.queryAlarmsByState(state, auth, filter)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms;
 		for (var k=0; k<alarms.length; k++){
-			returnMe += '*'+alarms[k].StateValue +'*: ' + 
+			returnMe += '*'+alarms[k].StateValue +'*: ' +
 			alarms[k].AlarmName + "\n";
 		}
 		return Promise.resolve(returnMe);
@@ -76,10 +80,11 @@ Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, ignore){
  * Returns a Promise containing the number of alarms in the state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.countAlarmsByState = function(state, auth, ignore){
-	return this.queryAlarmsByState(state, auth, ignore)
+Alarms.prototype.countAlarmsByState = function(state, auth, filter){
+	return this.queryAlarmsByState(state, auth, filter)
 	.then(function(data){
 		return Promise.resolve(data.MetricAlarms.length);
 	});
@@ -90,11 +95,12 @@ Alarms.prototype.countAlarmsByState = function(state, auth, ignore){
  * Returns a Promise containing a string with a health report, detailing the number of alarms in each state.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
  * @param {Object} params - Additional AWS Filters.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.healthReportByState = function(auth, params, ignore){
-	return this.getAllAlarms(auth, params, ignore)	
+Alarms.prototype.healthReportByState = function(auth, params, filter){
+	return this.getAllAlarms(auth, params, filter)
 	.then(function(data){
 		var alarms = data.MetricAlarms;
 		var numOK=0, numInsufficient=0, numAlarm=0;
@@ -121,10 +127,11 @@ Alarms.prototype.healthReportByState = function(auth, params, ignore){
  * Returns a Promise containing a JS object with all of the alarms that have one of the names on the watchlist.
  * @param {Array} watchlist - An array containing the names of alarms you'd like to query for.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, ignore){
-	return this.getAllAlarms(auth, {AlarmNames: watchlist}, ignore);
+Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, filter){
+	return this.getAllAlarms(auth, {AlarmNames: watchlist}, filter);
 };
 
 /**
@@ -132,15 +139,16 @@ Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, ignore){
  * Returns a promise resolving to a string containing information about all matching alarms.
  * @param {Array} watchlist - An array containing the names of alarms you'd like to query for.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, ignore){
-	return this.queryAlarmsByWatchlist(watchlist, auth, ignore)
+Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, filter){
+	return this.queryAlarmsByWatchlist(watchlist, auth, filter)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms ;
 		for (var k=0; k<alarms.length; k++){
-			returnMe += '*'+alarms[k].StateValue +'*: ' + 
+			returnMe += '*'+alarms[k].StateValue +'*: ' +
 			alarms[k].AlarmName + "\n";
 		}
 		return Promise.resolve(returnMe);
@@ -152,11 +160,12 @@ Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, igno
  * Returns a Promise containing a JS object with all of the alarms that have names that begin with the prefix.
  * @param {string} prefix - A prefix string. All alarms with names that begin with the prefix will be returned.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, ignore){
-	return this.getAllAlarms(auth, {AlarmNamePrefix: prefix}, ignore);
+Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, filter){
+	return this.getAllAlarms(auth, {AlarmNamePrefix: prefix}, filter);
 };
 
 /**
@@ -164,16 +173,17 @@ Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, ignore){
  * Returns a String containing information about all of the alarms that have names that begin with the prefix.
  * @param {string} prefix - A prefix string. All alarms with names that begin with the prefix will be returned.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Array} ignore - Optional list of names of alarms to ignore.
+ * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByPrefixReadably = function(prefix, auth, ignore){
-	return this.queryAlarmsByPrefix(prefix, auth, ignore)
+Alarms.prototype.queryAlarmsByPrefixReadably = function(prefix, auth, filter){
+	return this.queryAlarmsByPrefix(prefix, auth, filter)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms ;
 		for (var k=0; k<alarms.length; k++){
-			returnMe += '*'+alarms[k].StateValue +'*: ' + 
+			returnMe += '*'+alarms[k].StateValue +'*: ' +
 			alarms[k].AlarmName + "\n";
 		}
 		return Promise.resolve(returnMe);
@@ -206,7 +216,7 @@ Alarms.prototype.getMetricStatistics = function(auth, params, interval, numOfExe
 
 
 /**
- * Performs a single AWS CloudWatch metric query. 
+ * Performs a single AWS CloudWatch metric query.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
  * @param {Object} params - AWS query params.
  */

--- a/lib/alarms.js
+++ b/lib/alarms.js
@@ -11,10 +11,10 @@ function Alarms(){
  * Returns a Promise containing a JS object with all configured alarms.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
  * @param {Object} params - Additional AWS Parameters for describe-alarms.
- * @param {Function} filter - A predicate that receives a MetricAlarm map and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm map and
  * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.getAllAlarms = function(auth, params, filter, prevResults){
+Alarms.prototype.getAllAlarms = function(auth, params, filterPredicate, prevResults){
 	var self = this;
 	params = params || {};
 
@@ -26,10 +26,10 @@ Alarms.prototype.getAllAlarms = function(auth, params, filter, prevResults){
 		}
 		if (data.NextToken) {
 			params.NextToken = data.NextToken;
-			return self.getAllAlarms(auth, params, filter, data);
+			return self.getAllAlarms(auth, params, filterPredicate, data);
 		} else {
-			if (filter) {
-				data.MetricAlarms = _.filter(data.MetricAlarms, filter);
+			if (filterPredicate) {
+				data.MetricAlarms = _.filter(data.MetricAlarms, filterPredicate);
 			}
 			return Promise.resolve(data);
 		}
@@ -40,24 +40,24 @@ Alarms.prototype.getAllAlarms = function(auth, params, filter, prevResults){
  * Returns a Promise containing a JS object with all of the alarms currently in that state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByState = function(state, auth, filter){
-	return this.getAllAlarms(auth, {StateValue : state}, filter);
+Alarms.prototype.queryAlarmsByState = function(state, auth, filterPredicate){
+	return this.getAllAlarms(auth, {StateValue : state}, filterPredicate);
 };
 /**
  * Queries Cloudwatch alarms that are currently in a particular state.
  * Returns a Promise that resolves to a string containing information about each alarm in the queried state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, filter){
-	return this.queryAlarmsByState(state, auth, filter)
+Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, filterPredicate){
+	return this.queryAlarmsByState(state, auth, filterPredicate)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms;
@@ -74,11 +74,11 @@ Alarms.prototype.queryAlarmsByStateReadably = function(state, auth, filter){
  * Returns a Promise containing the number of alarms in the state.
  * @param {string} state - A string containing the state you'd like to query for (e.g. 'ALARM')
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.countAlarmsByState = function(state, auth, filter){
-	return this.queryAlarmsByState(state, auth, filter)
+Alarms.prototype.countAlarmsByState = function(state, auth, filterPredicate){
+	return this.queryAlarmsByState(state, auth, filterPredicate)
 	.then(function(data){
 		return Promise.resolve(data.MetricAlarms.length);
 	});
@@ -89,12 +89,12 @@ Alarms.prototype.countAlarmsByState = function(state, auth, filter){
  * Returns a Promise containing a string with a health report, detailing the number of alarms in each state.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
  * @param {Object} params - Additional AWS Filters.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.healthReportByState = function(auth, params, filter){
-	return this.getAllAlarms(auth, params, filter)
+Alarms.prototype.healthReportByState = function(auth, params, filterPredicate){
+	return this.getAllAlarms(auth, params, filterPredicate)
 	.then(function(data){
 		var alarms = data.MetricAlarms;
 		var numOK=0, numInsufficient=0, numAlarm=0;
@@ -121,11 +121,11 @@ Alarms.prototype.healthReportByState = function(auth, params, filter){
  * Returns a Promise containing a JS object with all of the alarms that have one of the names on the watchlist.
  * @param {Array} watchlist - An array containing the names of alarms you'd like to query for.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, filter){
-	return this.getAllAlarms(auth, {AlarmNames: watchlist}, filter);
+Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, filterPredicate){
+	return this.getAllAlarms(auth, {AlarmNames: watchlist}, filterPredicate);
 };
 
 /**
@@ -133,11 +133,11 @@ Alarms.prototype.queryAlarmsByWatchlist = function(watchlist, auth, filter){
  * Returns a promise resolving to a string containing information about all matching alarms.
  * @param {Array} watchlist - An array containing the names of alarms you'd like to query for.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
-Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, filter){
-	return this.queryAlarmsByWatchlist(watchlist, auth, filter)
+Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, filterPredicate){
+	return this.queryAlarmsByWatchlist(watchlist, auth, filterPredicate)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms ;
@@ -154,12 +154,12 @@ Alarms.prototype.queryAlarmsByWatchlistReadably = function(watchlist, auth, filt
  * Returns a Promise containing a JS object with all of the alarms that have names that begin with the prefix.
  * @param {string} prefix - A prefix string. All alarms with names that begin with the prefix will be returned.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, filter){
-	return this.getAllAlarms(auth, {AlarmNamePrefix: prefix}, filter);
+Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, filterPredicate){
+	return this.getAllAlarms(auth, {AlarmNamePrefix: prefix}, filterPredicate);
 };
 
 /**
@@ -167,12 +167,12 @@ Alarms.prototype.queryAlarmsByPrefix = function(prefix, auth, filter){
  * Returns a String containing information about all of the alarms that have names that begin with the prefix.
  * @param {string} prefix - A prefix string. All alarms with names that begin with the prefix will be returned.
  * @param {Auth} auth - An auth object made using the keys and region you'd like to use.
- * @param {Function} filter - A predicate that receives a MetricAlarm object and
+ * @param {Function} filterPredicate - A predicate that receives a MetricAlarm object and
  * returns true to include the alarm and false to exclude it.
  */
 
-Alarms.prototype.queryAlarmsByPrefixReadably = function(prefix, auth, filter){
-	return this.queryAlarmsByPrefix(prefix, auth, filter)
+Alarms.prototype.queryAlarmsByPrefixReadably = function(prefix, auth, filterPredicate){
+	return this.queryAlarmsByPrefix(prefix, auth, filterPredicate)
 	.then(function(data){
 		var returnMe = '';
 		var alarms = data.MetricAlarms ;

--- a/lib/alarms.js
+++ b/lib/alarms.js
@@ -29,13 +29,7 @@ Alarms.prototype.getAllAlarms = function(auth, params, filter, prevResults){
 			return self.getAllAlarms(auth, params, filter, data);
 		} else {
 			if (filter) {
-				var filteredAlarms = [];
-				for (var alarmIdx = 0; alarmIdx < data.MetricAlarms.length; alarmIdx++) {
-					if(filter(data.MetricAlarms[alarmIdx])) {
-						filteredAlarms.push(data.MetricAlarms[alarmIdx]);
-					}
-				}
-				data.MetricAlarms = filteredAlarms;
+				data.MetricAlarms = _.filter(data.MetricAlarms, filter);
 			}
 			return Promise.resolve(data);
 		}


### PR DESCRIPTION
In order to allow more powerful filtering of alarms, the `ignore` parameter of the `getAllAlarms` and related functions was changed to a `filterPredicate` function parameter that receives a map with the alarm properties and returns true to include the alarm and false to exclude it.